### PR TITLE
listen to events generated by highlights' decorations

### DIFF
--- a/lib/decoration-example-view.coffee
+++ b/lib/decoration-example-view.coffee
@@ -1,5 +1,6 @@
 {View} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
+EventsManager = require './events-manager'
 
 module.exports =
 class DecorationExampleView extends View
@@ -27,6 +28,7 @@ class DecorationExampleView extends View
   initialize: (serializeState) ->
     @decorationsByEditorId = {}
     disposables = new CompositeDisposable
+    @eventsManager = new EventsManager
 
     @toggleButtons =
       line: @lineToggle
@@ -83,6 +85,7 @@ class DecorationExampleView extends View
 
     # create a decoration that follows the marker. A Decoration object is returned which can be updated
     decoration = editor.decorateMarker(marker, type: type, class: "#{type}-#{@getRandomColor()}")
+    @eventsManager.doDecoration(decoration)
     decoration
 
   updateDecoration: (decoration, newDecorationParams) ->

--- a/lib/events-manager.coffee
+++ b/lib/events-manager.coffee
@@ -1,0 +1,67 @@
+View = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
+
+module.exports =
+class EventsManager
+  notify: ->
+    noteMessage = 'Try hovering over the gutter/line highlights.'
+    notifOnOff = atom.config.get('decoration-example.showconfignotification')
+    if notifOnOff == 'on' or typeof notifOnOff is 'undefined'
+      atom.notifications.addInfo noteMessage,
+        buttons: [ {
+          text: 'Don\'t show again'
+          onDidClick: (ev) ->
+            atom.config.set 'decoration-example.showconfignotification', 'off'
+            notes = atom.notifications.getNotifications()
+            i = 0
+            while i < notes.length
+              if notes[i].getMessage() == noteMessage
+                notes[i].dismiss()
+              i++
+            return
+        } ]
+        dismissable: true
+
+  #this currently works with only gutter and line decorations
+  doDecoration: (decoration) ->
+    @notify()
+    klass = decoration.getProperties().class
+    #we're interested in the current editor
+    edview = atom.views.getView(atom.workspace.getActiveTextEditor())
+    #We have to wait for the decoration
+    #To be added until atom's API implements some sort of
+    #callback on notification added.
+    #So for now we resort to a timeout callback
+    stocb = =>
+      #We identify our element by the klass added to it
+      #The text-editor relevant DOM elements
+      #All fall under a deprecated ::shadow pseudo element
+      shadowRoot = edview.shadowRoot
+      match = shadowRoot.querySelector(".#{klass}")
+      if (match != null)
+        #Get our object and play around with it
+        object = View.$(match)
+        #it is important to realize that this
+        #call back will run for any object that
+        #matches the above selector
+        #You can check the line number by reading
+        #the data-screen-row attribute
+        object.mouseover (ev) =>
+          #You can inspect object here via debugger or
+          #console.log(object)
+          sr = object.attr("data-screen-row")
+          console.log("moused over at screen row #{sr}")
+          divhtml = '<div class="my-div" style="top:' + (event.clientY-40) +
+                     'px;left:' + (event.clientX-120) + 'px;">\
+                        Moused over!
+                        </div>'
+          div = View.$(divhtml).appendTo("body")
+          div.mouseout =>
+            div.remove()
+        decoration.onDidDestroy =>
+          #once the decoration is gone
+          #we have to stop tracking the line-number div
+          #this will prevent the mouseover event to trigger
+          #again on the same line
+          object.off()
+    setTimeout stocb, 100

--- a/styles/event-notific.atom-text-editor.less
+++ b/styles/event-notific.atom-text-editor.less
@@ -1,0 +1,16 @@
+.my-div{
+  /* Those are the only two important
+   * css properties for our div to be visible*/
+  position:absolute;
+  z-index:3;
+
+  padding-top: 25px;
+  padding-bottom: 25px;
+  padding-left: 50px;
+  padding-right: 50px;
+  background-color: chartreuse;
+  border-radius: 5px;
+  font-size: 20px;
+  color: black;
+  font-weight: 500;
+}


### PR DESCRIPTION
Make line/gutter highlights mouseoverable. 
Adds a [permenantly dismissable] notification to let used know of  this feature

Example demonstrates how you can add/remove DOM elements and listen to their various javascript events.